### PR TITLE
🐛 Fix status checks

### DIFF
--- a/src/rf24.c
+++ b/src/rf24.c
@@ -515,8 +515,10 @@ rf24_status_t rf24_start_listening(rf24_dev_t* p_dev) {
             platform_status = rf24_platform_write_reg8(&(p_dev->platform_setup), NRF24L01_REG_CONFIG, reg_config.value);
             dev_status = (platform_status == RF24_PLATFORM_SUCCESS) ? (RF24_SUCCESS) : (RF24_ERROR_CONTROL_INTERFACE);
 
-            platform_status = rf24_platform_write_reg8(&(p_dev->platform_setup), NRF24L01_REG_STATUS, reg_status.value);
-            dev_status = (platform_status == RF24_PLATFORM_SUCCESS) ? (RF24_SUCCESS) : (RF24_ERROR_CONTROL_INTERFACE);
+            if (dev_status == RF24_SUCCESS) {
+                platform_status = rf24_platform_write_reg8(&(p_dev->platform_setup), NRF24L01_REG_STATUS, reg_status.value);
+                dev_status = (platform_status == RF24_PLATFORM_SUCCESS) ? (RF24_SUCCESS) : (RF24_ERROR_CONTROL_INTERFACE);
+            }
         }
     }
 

--- a/src/rf24_platform.c
+++ b/src/rf24_platform.c
@@ -109,7 +109,7 @@ rf24_platform_status_t rf24_platform_read_register(rf24_platform_t* p_setup, nrf
     hal_status = HAL_SPI_TransmitReceive(p_setup->hspi, &command, &(status_reg.value), 1, p_setup->spi_timeout);
 
     if (hal_status == HAL_OK) {
-        HAL_SPI_Receive(p_setup->hspi, buff, len, p_setup->spi_timeout);
+        hal_status = HAL_SPI_Receive(p_setup->hspi, buff, len, p_setup->spi_timeout);
     }
 
     rf24_end_transaction(p_setup);
@@ -135,7 +135,7 @@ rf24_platform_status_t rf24_platform_write_register(rf24_platform_t* p_setup, nr
     hal_status = HAL_SPI_TransmitReceive(p_setup->hspi, &command, &(status_reg.value), 1, p_setup->spi_timeout);
 
     if (hal_status == HAL_OK) {
-        HAL_SPI_Transmit(p_setup->hspi, buff, len, p_setup->spi_timeout);
+        hal_status = HAL_SPI_Transmit(p_setup->hspi, buff, len, p_setup->spi_timeout);
     }
 
     rf24_end_transaction(p_setup);
@@ -159,7 +159,7 @@ rf24_platform_status_t rf24_platform_read_payload(rf24_platform_t* p_setup, uint
     hal_status = HAL_SPI_TransmitReceive(p_setup->hspi, &command, &(status_reg.value), 1, p_setup->spi_timeout);
 
     if (hal_status == HAL_OK) {
-        HAL_SPI_Receive(p_setup->hspi, buff, len, p_setup->spi_timeout);
+        hal_status = HAL_SPI_Receive(p_setup->hspi, buff, len, p_setup->spi_timeout);
     }
 
     rf24_end_transaction(p_setup);
@@ -180,7 +180,7 @@ rf24_platform_status_t rf24_platform_write_payload(rf24_platform_t* p_setup, uin
     hal_status = HAL_SPI_TransmitReceive(p_setup->hspi, &command, &(status_reg.value), 1, p_setup->spi_timeout);
 
     if (hal_status == HAL_OK) {
-        HAL_SPI_Transmit(p_setup->hspi, buff, len, p_setup->spi_timeout);
+        hal_status = HAL_SPI_Transmit(p_setup->hspi, buff, len, p_setup->spi_timeout);
     }
 
     rf24_end_transaction(p_setup);


### PR DESCRIPTION
Adiciona a checagem dos status retornados por diversas funções das camadas mais baixas para melhorar a detecção de erros durante o funcionamento do módulo.

Testado com nRFDongle e TPM-VSS